### PR TITLE
Fix imports

### DIFF
--- a/beans/analyse.py
+++ b/beans/analyse.py
@@ -1,45 +1,19 @@
-import matplotlib.pyplot as plt
 import numpy as np
-import emcee
-import corner
-import random
-import math
-import subprocess
-from astropy.io import ascii
-import pickle
-from matplotlib.ticker import MaxNLocator
-import sys
-import idlsave
-from scipy.stats.kde import gaussian_kde
-import scipy.stats as stats
-import matplotlib.mlab as mlab
-import tables
-from scipy.interpolate import interp1d
-from chainconsumer import ChainConsumer
-from multiprocessing import Pool
-import os
-import time
-from multiprocessing import Pool
-import os
-import time
-import ast
-import matplotlib.gridspec as gridspec
 
 # -------------------------------------------------------------------------#
 ## load local  modules
-from settle import settle
-from burstrain import *
-from run_model import runmodel
-from get_data import get_obs
-from mrprior import mr_prior
-from get_data import *
-from run_emcee import runemcee
+from .burstrain import *
+from .run_model import runmodel
+from .get_data import get_obs
+from .mrprior import mr_prior
+from .get_data import *
+from .run_emcee import runemcee
 
 
 # def get_param_uncert_obs1(param_array, numburstssim):
 #     # Get uncertainties on individual parameters:
 #     p1, p2, p3, p4 ,p5, p6, p7 = map(lambda v: (v[1], v[2]-v[1], v[1]-v[0]), zip(*np.percentile(param_array, [16, 50, 84], axis=0)))
-#     # this will return 
+#     # this will return
 #     return p1, p2, p3, p4, p5, p6, p7
 
 def get_param_uncert_obs(param_array, numburstssim):
@@ -57,4 +31,3 @@ def get_param_uncert(param_array):
     # Get uncertainties on individual parameters:
     p = map(lambda v: (v[1], v[2]-v[1], v[1]-v[0]), zip(*np.percentile(param_array, [16, 50, 84], axis=0)))
     return p
-                                        

--- a/beans/beans.py
+++ b/beans/beans.py
@@ -3,23 +3,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import emcee
-import corner
-import random
-import math
-import subprocess
-from astropy.io import ascii
-import pickle
 from matplotlib.ticker import MaxNLocator
-import sys
-from scipy.stats.kde import gaussian_kde
-import scipy.stats as stats
-import matplotlib.mlab as mlab
-import tables
-from scipy.interpolate import interp1d
 from chainconsumer import ChainConsumer
-from multiprocessing import Pool
-import os
-import time
 
 try:
     # Required for the distance_limit method
@@ -29,18 +14,17 @@ except:
 
 # -------------------------------------------------------------------------#
 ## load local  modules
-from settle import settle
-from burstrain import generate_burst_train, next_burst, get_a_b, mean_flux
-from run_model import runmodel
-from get_data import get_obs
-from mrprior import mr_prior
-from get_data import get_obs
-from run_emcee import runemcee
-from analyse import get_param_uncert_obs, get_param_uncert
-from initialise import init
+from .burstrain import generate_burst_train, next_burst, get_a_b, mean_flux
+from .run_model import runmodel
+from .get_data import get_obs
+from .mrprior import mr_prior
+from .get_data import get_obs
+from .run_emcee import runemcee
+from .analyse import get_param_uncert_obs, get_param_uncert
+from .initialise import init
 
 # -------------------------------------------------------------------------#
-# Some example prior functions, or you can write your own for input to the code. 
+# Some example prior functions, or you can write your own for input to the code.
 
 # Define priors for theta. mr prior function is located in mrprior.py
 
@@ -728,4 +712,3 @@ class Beans:
         plt.tight_layout(h_pad=0.0)
         plt.savefig(self.run_id+'chain-plot.pdf')
         plt.show()
-

--- a/beans/burstrain.py
+++ b/beans/burstrain.py
@@ -1,9 +1,11 @@
 """ This module defines the functions that generate the burst train """
 
-import numpy as np
-from settle import settle
 import random
+
+import numpy as np
 import matplotlib.pyplot as plt
+
+from .settle import settle
 
 def mean_flux(t1, t2, tobs, a, b):
 

--- a/beans/initialise.py
+++ b/beans/initialise.py
@@ -2,37 +2,15 @@
 """Initialisation. This is the only place where you need to enter parameters."""
 
 ## Python packages required:
-import matplotlib.pyplot as plt
-import numpy as np
-import emcee
-import corner
-import random
-import math
-import subprocess
-from astropy.io import ascii
-import pickle
-from matplotlib.ticker import MaxNLocator
-import sys
-import idlsave
-from scipy.stats.kde import gaussian_kde
-import scipy.stats as stats
-import matplotlib.mlab as mlab
-import tables
-from scipy.interpolate import interp1d
-from chainconsumer import ChainConsumer
-from multiprocessing import Pool
-import os
-import time
 
 # -------------------------------------------------------------------------#
 ## load local  modules
-from settle import settle
-from burstrain import *
-from run_model import runmodel
-from get_data import get_obs
-from mrprior import mr_prior
-from get_data import *
-from run_emcee import runemcee
+from .burstrain import *
+from .run_model import runmodel
+from .get_data import get_obs
+from .mrprior import mr_prior
+from .get_data import *
+from .run_emcee import runemcee
 
 # -------------------------------------------------------------------------#
 # Begin the emcee initialisation:

--- a/beans/likelihood.py
+++ b/beans/likelihood.py
@@ -1,34 +1,13 @@
-import matplotlib.pyplot as plt
 import numpy as np
-import emcee
-import corner
-import random
-import math
-import subprocess
-from astropy.io import ascii
-import pickle
-from matplotlib.ticker import MaxNLocator
-import sys
-import idlsave
-from scipy.stats.kde import gaussian_kde
-import scipy.stats as stats
-import matplotlib.mlab as mlab
-import tables
-from scipy.interpolate import interp1d
-from chainconsumer import ChainConsumer
-from multiprocessing import Pool
-import os
-import time
 
 # -------------------------------------------------------------------------#
 ## load local  modules
-from settle import settle
-from burstrain import *
-from run_model import runmodel
-from get_data import get_obs
-from mrprior import mr_prior
-from get_data import *
-from initialise import init
+from .burstrain import *
+from .run_model import runmodel
+from .get_data import get_obs
+from .mrprior import mr_prior
+from .get_data import *
+from .initialise import init
 
 ## Now we define the functions that emcee requires
 # define likelihood as a function of theta, x, y and yerr as this is what emcee expects as the inputs
@@ -209,7 +188,7 @@ def lnprob(theta, x, y, yerr):
 
     # we return the logprobability as well as the theta parameters at this point so we can extract results later
     return lp + like, lp, model
-    
+
 
 
 # -------------------------------------------------------------- #

--- a/beans/mrprior.py
+++ b/beans/mrprior.py
@@ -1,9 +1,6 @@
 import pathlib
 
 import numpy as np
-import tables
-import matplotlib.pyplot as plt
-from scipy.interpolate import interp1d
 from scipy import stats
 
 # read in file

--- a/beans/run_emcee.py
+++ b/beans/run_emcee.py
@@ -1,10 +1,6 @@
 """ function to initiliase and run emcee. Please note this software uses the latest stable version of emcee (v2.2.1). """
 import numpy as np
 import emcee
-import sys
-import pickle
-from multiprocessing import Pool
-import time
 import h5py
 
 def runemcee(nwalkers, nsteps, ndim, theta, lnprob, x, y, yerr, run_id, restart):
@@ -26,8 +22,8 @@ def runemcee(nwalkers, nsteps, ndim, theta, lnprob, x, y, yerr, run_id, restart)
         # set the intial position of the walkers
         pos = [theta + 1e-4*np.random.randn(ndim) for i in range(nwalkers)]
         print('Ready to run',run_id,'with',nwalkers,'walkers')
-            
-    # with Pool() as pool: # for some reason the multi-threaded isn't working with the new emcee. Revert back to not using MPI. 
+
+    # with Pool() as pool: # for some reason the multi-threaded isn't working with the new emcee. Revert back to not using MPI.
 
     print("Beginning sampling..")
     # use emcee backend to save as a HD5 file
@@ -36,7 +32,7 @@ def runemcee(nwalkers, nsteps, ndim, theta, lnprob, x, y, yerr, run_id, restart)
         reader.reset(nwalkers, ndim)
         # sampler = emcee.EnsembleSampler(nwalkers, ndim, lnprob, args=(x, y, yerr), pool=pool, backend=reader, blobs_dtype=dtype, moves=emcee.moves.StretchMove(a=1.5))
     sampler = emcee.EnsembleSampler(nwalkers, ndim, lnprob, args=(x, y, yerr), backend=reader, blobs_dtype=dtype, moves=emcee.moves.StretchMove(a=1.5))
-    
+
 
 
     # We'll track how the average autocorrelation time estimate changes
@@ -56,7 +52,7 @@ def runemcee(nwalkers, nsteps, ndim, theta, lnprob, x, y, yerr, run_id, restart)
             # if it isn't trustworthy
             accept_frac = np.mean(sampler.acceptance_fraction)
             with open(f'{run_id}_acceptancefraction.txt', 'a') as f:
-                np.savetxt(f, [[float(sampler.iteration)],[accept_frac]], delimiter=',', newline='\n') 
+                np.savetxt(f, [[float(sampler.iteration)],[accept_frac]], delimiter=',', newline='\n')
 
             tau = sampler.get_autocorr_time(tol=0)
             autocorr[index] = np.mean(tau)
@@ -93,7 +89,7 @@ def runemcee(nwalkers, nsteps, ndim, theta, lnprob, x, y, yerr, run_id, restart)
 
         #tau = sampler.get_autocorr_time()
         print('Complete! WARNING max number of steps reached but chains may or may not be converged.')
-        
+
 
     #     print('Samples complete. Took {0:.1f} seconds'.format(multi_time))
 
@@ -112,4 +108,3 @@ def runemcee(nwalkers, nsteps, ndim, theta, lnprob, x, y, yerr, run_id, restart)
 
 
     return sampler
-

--- a/beans/run_model.py
+++ b/beans/run_model.py
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------#
 import numpy as np
-from burstrain import *
+from .burstrain import *
 
 def runmodel(theta_in, y, tref, bstart, pflux, pfluxe, tobs, numburstssim, ref_ind, gti_checking,
              gti_start=None, gti_end=None, debug=False):

--- a/beans/settle.py
+++ b/beans/settle.py
@@ -1,14 +1,15 @@
 """ Runs settle based on the input parameters and extracts the recurrence
 time, fluence and alphas """
 
-import settler as se
 import numpy as np
+
+from .settler import Settle
 
 
 def settle(base, z, x_0, mdot, cfac, mass, radius):
 
     # initialize settle interface
-    settl = se.Settle()
+    settl = Settle()
 
     # run settle:
     res = settl.full(F=base, M=mdot, X=x_0, Z=z, C=0, R=radius, Ma=mass)

--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,7 @@ dependencies:
   - numpy
   - scipy
   # Development
+  - black
+  - flake8
+  - isort
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,22 @@
+# Conda environment for beans usage and development
+#
+# Install:    conda env create --file environment.yml
+# Update:     conda env update --file environment.yml
+# Activate:   conda activate beans
+# Deactivate: conda deactivate
+
+name: beans
+channels:
+  - conda-forge
+  - samreay # for chainconsumer
+dependencies:
+  # Core
+  - astropy
+  - chainconsumer
+  - emcee
+  - h5py
+  - matplotlib
+  - numpy
+  - scipy
+  # Development
+  - pytest


### PR DESCRIPTION
This PR removes several unnecessary imports and makes beans module imports relative.

In addition, this PR adds a conda `environment.yml` file. The environment file can be used to make a conda environment to run beans in with

```bash
conda env create --file environment.yml
conda activate beans
```