### PR TITLE
Added fig6, fig8 plots; simplify posterior stats

### DIFF
--- a/beansp/__init__.py
+++ b/beansp/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Adelle Goodwin and Duncan Galloway"""
 __email__ = 'adelle.goodwin@curtin.edu.au'
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 # this allows "from beans import *"
 # __all__ = ["beans"]

--- a/beansp/analyse.py
+++ b/beansp/analyse.py
@@ -35,31 +35,43 @@ from .get_data import *
 from .run_emcee import runemcee
 
 
-# def get_param_uncert_obs1(param_array, numburstssim):
-#     # Get uncertainties on individual parameters:
-#     p1, p2, p3, p4 ,p5, p6, p7 = map(lambda v: (v[1], v[2]-v[1], v[1]-v[0]), zip(*np.percentile(param_array, [16, 50, 84], axis=0)))
-#     # this will return 
-#     return p1, p2, p3, p4, p5, p6, p7
+def get_param_uncert_obs(param_array, numburstssim, percentile=[16,50,84]):
+    '''
+    Get uncertainties on predicted parameters. This routine accepts a
+    list-of-lists with (for example) the start times of bursts for each
+    walker and each timestep:
+      [ [ t1, t2, t3, t4... tn ], 
+        [ t1, t2, t3, t4... tn ],
+            .
+            .
+            .
+    and calculates the 50th percentile value and +/- 1-sigma confidence
+    limits for each of the t1, t2, t3, returning a list-of-tuples for each
+    parameter, with the 50th percentile and the upper & lower uncertainties 
+    for each parameter in each tuple.
 
-def get_param_uncert_obs(param_array, numburstssim):
-    # Get uncertainties on individual parameters:
+    :param param_array: array listing the predicted values
+    :param numburstssim: number of events per instance (2nd dimension of
+      param_array)
+
+    :return: list of tuples giving parameter centroid and limits
+    '''
+
     plist = list()
     for i in range(0,numburstssim):
-        plist = map(lambda v: (v[1], v[2]-v[1], v[1]-v[0]), zip(*np.percentile(param_array, [16, 50, 84], axis=0)))
+        plist = map(lambda v: (v[1], v[2]-v[1], v[1]-v[0]),
+            zip(*np.percentile(param_array, percentile, axis=0)))
     plist2 = list()
     plist3 = list(plist)
     for i in range(0,numburstssim):
         plist2.append(plist3[i])
+
     return plist2
+
 
 def get_param_uncert(param_array, percentile=[16,50,84]):
     '''
-    Calculate uncertainties on individual parameterss.
-    This routine only works on unitless quantities (lists?)
-
-    TODO simplify this function (e.g. using numpy.diff) to allow it to
-    work on other kinds of structures, and avoid the list-to-numpy array
-    conversion in the predicted parameters in do_analysis
+    Calculate uncertainties on individual (scalar) parameters.
 
     :param param_array: array of parameter values to calculate percentiles
     :param percentile: percentiles to calculate, normally 1-sigma
@@ -67,8 +79,7 @@ def get_param_uncert(param_array, percentile=[16,50,84]):
       upper error and lower error
     '''
 
-    p = map(lambda v: (v[1], v[2]-v[1], v[1]-v[0]), 
-        zip(*np.percentile(param_array, percentile, axis=0)))
+    v = np.percentile(param_array, percentile, axis=0)
 
-    return p
+    return np.array([v[1], v[2]-v[1], v[1]-v[0]])
 

--- a/beansp/run_emcee.py
+++ b/beansp/run_emcee.py
@@ -148,25 +148,7 @@ def runemcee(nwalkers, nsteps, theta, lnprob, prior, x, y, yerr, run_id, restart
                     break
                 old_tau = tau
 
-
-        #tau = sampler.get_autocorr_time()
         print('Complete! WARNING max number of steps reached but chains may or may not be converged.')
-        
-    #     print('Samples complete. Took {0:.1f} seconds'.format(multi_time))
-
-    # with Pool() as pool:
-    #     print("Beginning sampling..")
-    #     # use emcee backend to save as a HD5 file
-    #     reader = emcee.backends.HDFBackend(f"chains_{run_id}.h5")
-    #     reader.reset(nwalkers, ndim)
-    #     sampler = emcee.EnsembleSampler(nwalkers, ndim, lnprob, args=(x, y, yerr), pool=pool, backend=reader, blobs_dtype=dtype)
-    #     start = time.time()
-    #     sampler.run_mcmc(pos, nsteps, progress=True, store=True)
-    #     end = time.time()
-    #     multi_time = end-start
-
-    #     print('Samples complete. Took {0:.1f} seconds'.format(multi_time))
-
 
     return sampler
 


### PR DESCRIPTION
Added options to reproduce Figures 6 and 8 from Goodwin et al. 2019. Figure 8 requires model predictions for xi_b, xi_p from the concord package; if that's not available a warning will be shown, but the plot will still be produced (omitting those lines).

Simplified the parameter calculations and the way the predictions are extracted, and also applied the burnin parameter also to the blobs