### PR TITLE
Reduced redundancy in blobs, model dict

### DIFF
--- a/beansp/__init__.py
+++ b/beansp/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Adelle Goodwin and Duncan Galloway"""
 __email__ = 'adelle.goodwin@curtin.edu.au'
-__version__ = '1.3.0'
+__version__ = '1.4.0'
 
 # this allows "from beans import *"
 # __all__ = ["beans"]

--- a/beansp/burstrain.py
+++ b/beansp/burstrain.py
@@ -269,7 +269,8 @@ def next_burst(
 
 
 def generate_burst_train( base, z, x_0, r1, r2, r3, mass, radius,
-    bstart, pflux, pfluxe, tobs, numburstssim, ref_ind, debug=False):
+    bstart, pflux, pfluxe, tobs, numburstssim, ref_ind, full_model=False, 
+    debug=False):
     """
     This routine generates a simulated burst train based on the model
     input parameters, and the mdot history inferred from the persistent
@@ -290,6 +291,8 @@ def generate_burst_train( base, z, x_0, r1, r2, r3, mass, radius,
     :param tobs: times for the persistent flux measurements
     :param numburstssim: number of bursts to simulate (in each direction)
     :param ref_ind: index of reference burst
+    :param full_model: if set to True, include all the parameters in the
+      dict that is returned
     :param debug: set to True to show additional debugging information
 
     :return: a dictionary with the following keys:
@@ -433,45 +436,41 @@ def generate_burst_train( base, z, x_0, r1, r2, r3, mass, radius,
 
     result = dict()
 
-    result["base"] = [base]
-    result["z"] = [z]
-    result["x_0"] = [x_0]
-    result["r1"] = [r1]
-    result["r2"] = [r2]
-    result["r3"] = [r3]
+    if full_model:
+        # model parameters are redundant for the model returned
+        result["base"] = [base]
+        result["z"] = [z]
+        result["x_0"] = [x_0]
+        result["r1"] = [r1]
+        result["r2"] = [r2]
+        result["r3"] = [r3]
+
+        result["mdot_max"] = [mdot_max]
+
+        result["mass"] = [mass]
+        result["radius"] =  [radius]
+
+        result["forward"] = forward     # to keep track of the outcome of each direction
+        result["backward"] = backward
+
+    # now the actual predictions
+
     result["time"] = stime
-    result["mdot_max"] = [mdot_max]
     if len(stime) > 0:
         # The simulation might fail to generate any bursts, so only add the arrays if they exist
         result["mdot"] = smdot
-        result["iref"] = iref
+        # this is redundant, can be worked out from the times
+        # result["iref"] = iref
         result["alpha"] = salpha
         result["e_b"] = se_b
         #print(f"In burstrain fluence is {se_b}")
 
-    # result["qnuc"] = sqnuc
-    # result["xbar"] = sxbar
-    result["mass"] = [mass]
-    result["radius"] =  [radius]
-    result["forward"] = forward     # to keep track of the outcome of each direction
-    result["backward"] = backward
 
     return result
 
 
-def burstensemble(
-    base,
-    x_0,
-    z,
-    r1,
-    r2,
-    r3,
-    mass,
-    radius,
-    bstart,
-    pflux,
-    numburstsobs,
-):
+def burstensemble( base, x_0, z, r1, r2, r3, mass, radius, bstart, pflux,
+    numburstsobs, full_model=False ):
     """
     This routine generates as many burst predictions as there are burst
     measurements.
@@ -519,24 +518,29 @@ def burstensemble(
 
     result = dict()
 
-    result["base"] = [base]
-    result["z"] = [z]
-    result["x_0"] = [x_0]
-    result["r1"] = [r1]
-    result["r2"] = [r2]
-    result["r3"] = [r3]
-    result["mdot"] = smdot
-    result["mdot_max"] = [mdot_max]
+    if full_model:
+        # model parameters are redundant for the model returned
+        result["base"] = [base]
+        result["z"] = [z]
+        result["x_0"] = [x_0]
+        result["r1"] = [r1]
+        result["r2"] = [r2]
+        result["r3"] = [r3]
+
+        result["mdot_max"] = [mdot_max]
+
+        result["mass"] = [mass]
+        result["radius"] = [radius]
+
+    # now the actual predictions
+
     result["time"] = stime
+    result["mdot"] = smdot
     result["alpha"] = salpha
     result["e_b"] = se_b
-
-    result["mass"] = [mass]
-    result["radius"] = [radius]
 
     # omit the printing for now, as it prevents assessing the progress
     # print('ensemble')
     # print(f"In burstrain fluence is {se_b}")
-
 
     return result

--- a/beansp/run_emcee.py
+++ b/beansp/run_emcee.py
@@ -64,16 +64,17 @@ def runemcee(nwalkers, nsteps, theta, lnprob, prior, x, y, yerr, run_id, restart
     print("# -------------------------------------------------------------------------#")
 
     # define the dtype of the blobs
-    #dtype = [("lnprob", float), ("model", "S1000")]
-    dtype = [("lnprob", float), ("model", h5py.string_dtype(encoding='ascii'))]
+    # this refers to the 2nd and subsequent parameters returned by lnprob;
+    # in our case the prior probability and the full model result, encoded
+    # as ASCII
+
+    dtype = [("lnprior", float), ("model", h5py.string_dtype(encoding='ascii'))]
 
     # use emcee backend to save as a HD5 file
     # see https://emcee.readthedocs.io/en/stable/user/backends
     reader = emcee.backends.HDFBackend(filename=run_id + ".h5")
 
     if restart == True:
-        # don't know why the pos are identical to the restart=False case below;
-        # perhaps they're ignored
         steps_so_far = np.shape(reader.get_chain())[0]
         print('Restarting',run_id,'with',nwalkers,'walkers after',steps_so_far,'steps done')
     else:


### PR DESCRIPTION
Adjusted the generate_burst_train and burstensemble routines to include a full_model option, which (if set to False, as is the default) omits the redundant (input parameters) being included in the dict returned.

This reduction in the size of the dict is then passed through to the .h5 file, reducing the size of each blob (and the overall .h5 file) by an estimated ~40%.

The do_analysis routine has been tweaked to apply the burnin also to the blobs, and extract the parameters more efficiently.