### PR TITLE
Added alpha parameter to toggle alpha comparison

### DIFF
--- a/beansp/__init__.py
+++ b/beansp/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Adelle Goodwin and Duncan Galloway"""
 __email__ = 'adelle.goodwin@curtin.edu.au'
-__version__ = '2.0.7'
+__version__ = '2.1.0'
 
 # this allows "from beans import *"
 # __all__ = ["beans"]


### PR DESCRIPTION
May be redundant to *also* compare alphas, as well as fluences and recurrence times; it can also be difficult to confidently determine alpha where there may have been burst gaps. So now have the alpha option on init to include the alphas (if set True), or not (if False). This switch shortens the y array as used for the model-obs comparison as initialised in get_obs, requiring alsochanges in lnlike

A few other minor changes, including to the __str__ method; read_config and save_config (added the alpha parameter, conditional for some of the others)