### PR TITLE
Fix the burst matching procedure

### DIFF
--- a/beansp/__init__.py
+++ b/beansp/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Adelle Goodwin and Duncan Galloway"""
 __email__ = 'adelle.goodwin@curtin.edu.au'
-__version__ = '2.7.0'
+__version__ = '2.8.0'
 
 # this allows "from beans import *"
 # __all__ = ["beans"]

--- a/beansp/__init__.py
+++ b/beansp/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Adelle Goodwin and Duncan Galloway"""
 __email__ = 'adelle.goodwin@curtin.edu.au'
-__version__ = '2.6.3'
+__version__ = '2.7.0'
 
 # this allows "from beans import *"
 # __all__ = ["beans"]

--- a/beansp/beans.py
+++ b/beansp/beans.py
@@ -1346,7 +1346,7 @@ Initial parameters:
         | probs - likelihoods (total, prior, and contributions from each parameter) for the last walker positions
         | cc - ChainConsumer object with samples and derived cosi, gravity, redshift
         | cc_parameters - plot labels for cc object
-        | blobs - dictionary with model realisations read in from the "blobs"
+        | model_pred - dictionary with model realisations read in from the "blobs"
 
 	By default the method will also create several files, labeled by
         the run_id; drawn from
@@ -1478,7 +1478,9 @@ Initial parameters:
             self.cc = ChainConsumer()
             _samples =np.column_stack((self.samples, cosi, gravity, redshift))
             # self.cc.add_chain(_samples, parameters=_labels)
-            self.cc.add_chain(_samples, parameters=list(_plot_labels.values()))
+            self.cc.add_chain(_samples, parameters=list(_plot_labels.values()),
+                name=self.run_id)
+            self.cc.configure(usetex=True, serif=True)
             self.samples = _samples # keep the samples up to date
             self.cc_parameters = _plot_labels
             self.cc_nchain = 1 # initially
@@ -1633,7 +1635,7 @@ Each row has the 50th percentile value, upper & lower 68% uncertainties'''.forma
                 diagonal_tick_labels=False, max_ticks=3, shade=True, \
                 shade_alpha=1.0 ,bar_shade=True, tick_font_size='xx-large', \
                 label_font_size='xx-large',smooth=True, \
-                sigmas=np.linspace(0, 3, 4), usetex=True, serif=True)
+                sigmas=np.linspace(0, 3, 4))
             if savefig:
                 self.cc.plotter.plot(
                     parameters=[self.cc_parameters[x] for x in ['X','Z','Qb','d','xi_b','xi_p']],

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ corner
 astropy
 scipy
 tables
-chainconsumer 
+chainconsumer<=0.34.0
 pytest
 sphinx_rtd_theme


### PR DESCRIPTION
Main goal of this branch was to develop a new way to match the predicted and observed bursts, which is now done with run_model.burst_time_match

The previous matching algorithm was too slow when you have lots of bursts, so replaced with a two stage process that will do an initial assignment, and then review to get the smallest RMS offset
    
Also some additional minor changes to make exploratory work easier; matching is not performed for plot_model etc.
