### PR TITLE
fixes to generate_burst_train, burst_table

### DIFF
--- a/beansp/__init__.py
+++ b/beansp/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Adelle Goodwin and Duncan Galloway"""
 __email__ = 'adelle.goodwin@curtin.edu.au'
-__version__ = '2.25.1'
+__version__ = '2.26.0'
 
 # this allows "from beans import *"
 # __all__ = ["beans"]

--- a/beansp/burstrain.py
+++ b/beansp/burstrain.py
@@ -330,8 +330,10 @@ def generate_burst_train( bean, base, x_0, z, dist, xi_p, mass, radius,
         if not (forward or backward):
             break
 
-    if (mdot_max == -1) & (len(stime) > 0):
+    if (mdot_max == -1) & (len(stime) > 1):
 
+        # only run this if len(stime) > 1, because it is initialised as a
+        # list with a single value (sbt)
         mdot_max = max(smdot)
 
     result = dict()


### PR DESCRIPTION
Modified generate_burst_train to check for more than one predicted time as indicating a valid model, as the reference burst time is added initially to the result list before any simulations are performed

Minor fix to the plot method to ignore invalid models

Modified the burst_table method to better handle masked or non-numeric values in the input arrays